### PR TITLE
ci: avoid obsolete code validation runs

### DIFF
--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -7,12 +7,17 @@ name: Code validation
 on:
   push:
     branches:
-      - '**'
+      - 'main'
   pull_request:
     types: [opened, synchronize]
+  workflow_dispatch:
 env:
   CI: true
   HUSKY: 0
+
+concurrency:
+  group: code-validation-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   commitlint:


### PR DESCRIPTION
There is no need to run code validation twice for same code