### PR TITLE
chore: fix repository url in package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/sebastian-nowak/reago.git"
+    "url": "git+https://github.com/sebastian-nowak/reago.git"
   },
   "type": "module",
   "workspaces": [

--- a/package/reago/package.json
+++ b/package/reago/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://reago.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/sebastian-nowak/reago.git",
+    "url": "git+https://github.com/sebastian-nowak/reago.git",
     "directory": "package/reago"
   },
   "bugs": {


### PR DESCRIPTION
`npm publish` complained about the previous url format