### PR TITLE
docs: toggle between the light and dark themes automatically

### DIFF
--- a/documentation/.vitepress/config.ts
+++ b/documentation/.vitepress/config.ts
@@ -24,6 +24,16 @@ export default defineConfig({
   head: [
     ['link', {rel: 'icon', href: '/favicon.ico', sizes: '48x48'}],
     ['link', {rel: 'icon', href: '/favicon.svg', sizes: 'any', type: 'image/svg+xml'}],
+    ['script', {}, `
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+        const cl = document.documentElement.classList;
+        cl.add('disable-transitions');
+        cl.toggle('dark', e.matches);
+        setTimeout(() => {
+          cl.remove('disable-transitions', e.matches);
+        }, 0);
+      });
+    `],
     ...(process.env.NODE_ENV === 'production' ? [
       ['script', {
         defer: 'true',

--- a/documentation/.vitepress/theme/style.scss
+++ b/documentation/.vitepress/theme/style.scss
@@ -20,6 +20,13 @@
 }
 
 
+// Global
+
+.disable-transitions * {
+  transition: unset !important;
+}
+
+
 // Navigation bar
 
 :root {


### PR DESCRIPTION
Really weird vitepress doesn't do it on its own, when using `appearance: 'force-auto'`.
